### PR TITLE
Updated to latest version of reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = ["api-bindings", "multimedia"]
 
 [dependencies]
-reqwest = "0.7.3"
+reqwest = "0.9.4"
 rust-crypto = "0.2.36"
 serde = "1.0.2"
 serde_derive = "1.0.2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,7 +36,7 @@ pub struct LastFmClient {
 impl LastFmClient {
     pub fn new(api_key: String, api_secret: String) -> LastFmClient {
         let partial_auth = AuthCredentials::new_partial(api_key, api_secret);
-        let http_client = Client::new().unwrap();
+        let http_client = Client::new();
 
         LastFmClient {
             auth: partial_auth,
@@ -126,11 +126,11 @@ impl LastFmClient {
         self.api_request(operation, req_params)
     }
 
-    fn api_request(&self, operation: ApiOperation, params: HashMap<String, String>) -> Result<String, String> {            
+    fn api_request(&self, operation: ApiOperation, params: HashMap<String, String>) -> Result<String, String> {
         match self.send_request(operation, params) {
             Ok(mut resp) => {
                 let status = resp.status();
-                if status != StatusCode::Ok {
+                if status != StatusCode::OK {
                     return Err(format!("Non Success status ({})", status));
                 }
 
@@ -153,8 +153,8 @@ impl LastFmClient {
         req_params.insert("api_sig".to_string(), signature);
 
         self.http_client
-            .post(url)?
-            .form(&req_params)?
+            .post(url)
+            .form(&req_params)
             .send()
     }
 


### PR DESCRIPTION
The main benefit from this update is to transitively remove a dependency on an outdated version of OpenSSL. See https://github.com/sfackler/rust-openssl/issues/987
