### PR TITLE
Added support for the web authentication flow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = ["api-bindings", "multimedia"]
 
 [dependencies]
-reqwest = "0.9.4"
+reqwest = "0.7.3"
 rust-crypto = "0.2.36"
 serde = "1.0.2"
 serde_derive = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = ["api-bindings", "multimedia"]
 
 [dependencies]
-reqwest = "0.7.3"
+reqwest = "0.9.4"
 rust-crypto = "0.2.36"
 serde = "1.0.2"
 serde_derive = "1.0.2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,7 +36,7 @@ pub struct LastFmClient {
 impl LastFmClient {
     pub fn new(api_key: String, api_secret: String) -> LastFmClient {
         let partial_auth = AuthCredentials::new_partial(api_key, api_secret);
-        let http_client = Client::new().unwrap();
+        let http_client = Client::new();
 
         LastFmClient {
             auth: partial_auth,
@@ -126,11 +126,11 @@ impl LastFmClient {
         self.api_request(operation, req_params)
     }
 
-    fn api_request(&self, operation: ApiOperation, params: HashMap<String, String>) -> Result<String, String> {            
+    fn api_request(&self, operation: ApiOperation, params: HashMap<String, String>) -> Result<String, String> {
         match self.send_request(operation, params) {
             Ok(mut resp) => {
                 let status = resp.status();
-                if status != StatusCode::Ok {
+                if status != StatusCode::OK {
                     return Err(format!("Non Success status ({})", status));
                 }
 
@@ -153,8 +153,8 @@ impl LastFmClient {
         req_params.insert("api_sig".to_string(), signature);
 
         self.http_client
-            .post(url)?
-            .form(&req_params)?
+            .post(url)
+            .form(&req_params)
             .send()
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,7 +38,7 @@ pub struct LastFmClient {
 impl LastFmClient {
     pub fn new(api_key: String, api_secret: String) -> LastFmClient {
         let partial_auth = AuthCredentials::new_partial(api_key, api_secret);
-        let http_client = Client::new();
+        let http_client = Client::new().unwrap();
 
         LastFmClient {
             auth: partial_auth,
@@ -146,11 +146,11 @@ impl LastFmClient {
         self.api_request(operation, req_params)
     }
 
-    fn api_request(&self, operation: ApiOperation, params: HashMap<String, String>) -> Result<String, String> {
+    fn api_request(&self, operation: ApiOperation, params: HashMap<String, String>) -> Result<String, String> {            
         match self.send_request(operation, params) {
             Ok(mut resp) => {
                 let status = resp.status();
-                if status != StatusCode::OK {
+                if status != StatusCode::Ok {
                     return Err(format!("Non Success status ({})", status));
                 }
 
@@ -173,8 +173,8 @@ impl LastFmClient {
         req_params.insert("api_sig".to_string(), signature);
 
         self.http_client
-            .post(url)
-            .form(&req_params)
+            .post(url)?
+            .form(&req_params)?
             .send()
     }
 

--- a/src/scrobbler.rs
+++ b/src/scrobbler.rs
@@ -26,7 +26,7 @@ impl Scrobbler {
     /// Uses the given username and password (for the user to log scrobbles against), plus
     /// the API key and API secret to authenticate with Last.fm API using 'getMobileSession'
     /// authentication scheme.
-    #[deprecated(since="0.9.1", note="Use `authenticate_with_password` or `authenticate_with_session_key`")]
+    #[deprecated(since="0.9.1", note="Use `authenticate_with_password`, `authenticate_with_token` or `authenticate_with_session_key`")]
     pub fn authenticate(&mut self, username: String, password: String) -> Result<SessionResponse> {
         self.authenticate_with_password(username, password)
     }
@@ -35,6 +35,13 @@ impl Scrobbler {
         self.client.set_user_credentials(username, password);
         self.client
             .authenticate_with_password()
+            .map_err(ScrobblerError::new)
+    }
+
+     pub fn authenticate_with_token(&mut self, token: String) -> Result<SessionResponse> {
+        self.client.set_user_token(token);
+        self.client
+            .authenticate_with_token()
             .map_err(ScrobblerError::new)
     }
 


### PR DESCRIPTION
In this flow, users of the library supply a authentication token instead of a username/login password combo.

(Sorry for the messy history, I accidentally started this branch from the dependencies update branch instead of master).