### PR TITLE
Update reqwest version to 0.9.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = ["api-bindings", "multimedia"]
 
 [dependencies]
-reqwest = "0.7.3"
+reqwest = "0.9.15"
 rust-crypto = "0.2.36"
 serde = "1.0.2"
 serde_derive = "1.0.2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,7 +38,7 @@ pub struct LastFmClient {
 impl LastFmClient {
     pub fn new(api_key: String, api_secret: String) -> LastFmClient {
         let partial_auth = AuthCredentials::new_partial(api_key, api_secret);
-        let http_client = Client::new().unwrap();
+        let http_client = Client::new();
 
         LastFmClient {
             auth: partial_auth,
@@ -150,7 +150,7 @@ impl LastFmClient {
         match self.send_request(operation, params) {
             Ok(mut resp) => {
                 let status = resp.status();
-                if status != StatusCode::Ok {
+                if status != StatusCode::OK {
                     return Err(format!("Non Success status ({})", status));
                 }
 
@@ -173,8 +173,8 @@ impl LastFmClient {
         req_params.insert("api_sig".to_string(), signature);
 
         self.http_client
-            .post(url)?
-            .form(&req_params)?
+            .post(url)
+            .form(&req_params)
             .send()
     }
 


### PR DESCRIPTION
Apparently the changes from #25 were lost, causing the crate to fail to build due to an out of date OpenSSL version. This PR updates the reqwest dependency so that it builds again.