### PR TITLE
Migration to edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["lastfm", "last-fm", "scrobble", "api"]
 license = "MIT"
 readme = "README.md"
 categories = ["api-bindings", "multimedia"]
+edition = "2018"
 
 [dependencies]
 reqwest = "0.9.15"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,5 +1,3 @@
-extern crate rustfm_scrobble;
-
 use rustfm_scrobble::{Scrobbler, Scrobble};
 
 // Example rustfm-scrobble client showing authentication, now playing and

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -39,8 +39,8 @@ impl UserCredentials {
 impl AuthCredentials {
     pub fn new_partial(api_key: String, api_secret: String) -> AuthCredentials {
         AuthCredentials {
-            api_key: api_key,
-            api_secret: api_secret,
+            api_key,
+            api_secret,
             credentials: None,
             session_key: None,
         }
@@ -48,8 +48,8 @@ impl AuthCredentials {
 
     pub fn set_user_credentials(&mut self, username: String, password: String) {
         self.credentials = Some(Credentials::UserSupplied(UserCredentials {
-            username: username,
-            password: password
+            username,
+            password
         }));
 
         // Invalidate session because we have new credentials

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::io::Read;
+use std::fmt;
 use reqwest;
 use reqwest::{Client, StatusCode};
 use serde_json;
@@ -18,15 +19,15 @@ pub enum ApiOperation {
     Scrobble,
 }
 
-impl ApiOperation {
-    fn to_string(&self) -> String {
-        match *self {
+impl fmt::Display for ApiOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let str = match *self {
             ApiOperation::AuthWebSession => "auth.getSession",
             ApiOperation::AuthMobileSession => "auth.getMobileSession",
             ApiOperation::NowPlaying => "track.updateNowPlaying",
             ApiOperation::Scrobble => "track.scrobble",
-        }
-        .to_string()
+        };
+        write!(f, "{}", str)
     }
 }
 
@@ -42,7 +43,7 @@ impl LastFmClient {
 
         LastFmClient {
             auth: partial_auth,
-            http_client: http_client,
+            http_client,
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,8 +6,8 @@ use reqwest;
 use reqwest::{Client, StatusCode};
 use serde_json;
 
-use auth::AuthCredentials;
-use models::responses::{AuthResponse, SessionResponse, NowPlayingResponse,
+use crate::auth::AuthCredentials;
+use crate::models::responses::{AuthResponse, SessionResponse, NowPlayingResponse,
                         NowPlayingResponseWrapper, ScrobbleResponse, ScrobbleResponseWrapper,
                         BatchScrobbleResponse, BatchScrobbleResponseWrapper};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,6 @@
 //!
 //! Client for the Last.fm Scrobble API v2.0.
 
-extern crate reqwest;
-extern crate crypto;
-
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-extern crate serde;
-
 #[macro_use]
 extern crate wrapped_vec;
 
@@ -18,14 +10,14 @@ mod client;
 mod auth;
 mod models;
 
-pub use scrobbler::{Scrobbler, ScrobblerError};
-pub use models::metadata::{Scrobble, ScrobbleBatch};
+pub use crate::scrobbler::{Scrobbler, ScrobblerError};
+pub use crate::models::metadata::{Scrobble, ScrobbleBatch};
 
 pub mod responses {
-    pub use models::responses::{SessionResponse, NowPlayingResponse, ScrobbleResponse,
+    pub use crate::models::responses::{SessionResponse, NowPlayingResponse, ScrobbleResponse,
                                 BatchScrobbleResponse};
-    
+
     pub mod values {
-        pub use models::responses::{CorrectableString, ScrobbleList};
+        pub use crate::models::responses::{CorrectableString, ScrobbleList};
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,7 +2,7 @@ pub mod responses {
 
     use std::fmt;
 
-    use serde;
+    use serde::Deserialize;
     use serde_json as json;
 
     #[derive(Deserialize, Debug)]
@@ -82,7 +82,7 @@ pub mod responses {
         fn deserialize_corrected_field<'de, D>(de: D) -> Result<bool, D::Error>
             where D: serde::Deserializer<'de>
         {
-            let deser_result: json::Value = try!(serde::Deserialize::deserialize(de));
+            let deser_result: json::Value = r#try!(serde::Deserialize::deserialize(de));
             match deser_result {
                 json::Value::String(ref s) if &*s == "1" => Ok(true),
                 json::Value::String(ref s) if &*s == "0" => Ok(false),
@@ -92,7 +92,7 @@ pub mod responses {
     }
 
     impl fmt::Display for CorrectableString {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "{}", self.text)
         }
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -121,7 +121,7 @@ pub mod metadata {
         /// Constructs a new Scrobble instance, representing a music track
         /// played in the past.
         pub fn new(artist: String, track: String, album: String) -> Scrobble {
-            Scrobble{ artist: artist, track: track, album: album, timestamp: None }
+            Scrobble{ artist, track, album, timestamp: None }
         }
 
         pub fn with_timestamp(&mut self, timestamp: u64) -> &mut Scrobble {

--- a/src/scrobbler.rs
+++ b/src/scrobbler.rs
@@ -20,7 +20,7 @@ impl Scrobbler {
     pub fn new(api_key: String, api_secret: String) -> Scrobbler {
         let client = LastFmClient::new(api_key, api_secret);
 
-        Scrobbler { client: client }
+        Scrobbler { client }
     }
 
     /// Uses the given username and password (for the user to log scrobbles against), plus
@@ -64,7 +64,7 @@ impl Scrobbler {
     pub fn scrobble(&self, scrobble: Scrobble) -> Result<ScrobbleResponse> {
         let mut params = scrobble.as_map();
 
-        params.entry("timestamp".to_string()).or_insert(format!("{}", UNIX_EPOCH.elapsed().unwrap().as_secs()));
+        params.entry("timestamp".to_string()).or_insert_with(|| format!("{}", UNIX_EPOCH.elapsed().unwrap().as_secs()));
 
         self.client
             .send_scrobble(&params)
@@ -77,13 +77,13 @@ impl Scrobbler {
         let batch_count = batch.len();
         if batch_count > 50 {
             return Err(ScrobblerError::new("Scrobble batch too large (must be 50 or fewer scrobbles)".to_owned()));
-        } else if batch_count <= 0 {
+        } else if batch_count == 0 {
             return Err(ScrobblerError::new("Scrobble batch is empty".to_owned()));
         }
 
         for (i, scrobble) in batch.iter().enumerate() {
             let mut scrobble_params = scrobble.as_map();
-            scrobble_params.entry("timestamp".to_string()).or_insert(format!("{}", UNIX_EPOCH.elapsed().unwrap().as_secs()));
+            scrobble_params.entry("timestamp".to_string()).or_insert_with(|| format!("{}", UNIX_EPOCH.elapsed().unwrap().as_secs()));
 
             for (key, val) in scrobble_params.iter() {
                 // batched parameters need array notation suffix ie.
@@ -113,7 +113,7 @@ pub struct ScrobblerError {
 
 impl ScrobblerError {
     pub fn new(err_msg: String) -> ScrobblerError {
-        ScrobblerError { err_msg: err_msg }
+        ScrobblerError { err_msg }
     }
 }
 

--- a/src/scrobbler.rs
+++ b/src/scrobbler.rs
@@ -1,6 +1,6 @@
-use client::LastFmClient;
-use models::responses::{SessionResponse, NowPlayingResponse, ScrobbleResponse, BatchScrobbleResponse};
-use models::metadata::{Scrobble, ScrobbleBatch};
+use crate::client::LastFmClient;
+use crate::models::responses::{SessionResponse, NowPlayingResponse, ScrobbleResponse, BatchScrobbleResponse};
+use crate::models::metadata::{Scrobble, ScrobbleBatch};
 
 use std::collections::HashMap;
 use std::time::UNIX_EPOCH;
@@ -118,7 +118,7 @@ impl ScrobblerError {
 }
 
 impl fmt::Display for ScrobblerError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.err_msg)
     }
 }
@@ -128,7 +128,7 @@ impl Error for ScrobblerError {
         self.err_msg.as_str()
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }


### PR DESCRIPTION
* make migration to edition 2018 and apply edition-idioms
* apply all clippy suggestions:
```
    Checking rustfm-scrobble v0.9.2 (/Users/ander/work/crates/rustfm-scrobble)
warning: redundant field names in struct initialization
  --> src/scrobbler.rs:23:21
   |
23 |         Scrobbler { client: client }
   |                     ^^^^^^^^^^^^^^ help: replace it with: `client`
   |
   = note: `#[warn(clippy::redundant_field_names)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/scrobbler.rs:116:26
    |
116 |         ScrobblerError { err_msg: err_msg }
    |                          ^^^^^^^^^^^^^^^^ help: replace it with: `err_msg`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
  --> src/client.rs:45:13
   |
45 |             http_client: http_client,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `http_client`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
  --> src/auth.rs:42:13
   |
42 |             api_key: api_key,
   |             ^^^^^^^^^^^^^^^^ help: replace it with: `api_key`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
  --> src/auth.rs:43:13
   |
43 |             api_secret: api_secret,
   |             ^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `api_secret`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
  --> src/auth.rs:51:13
   |
51 |             username: username,
   |             ^^^^^^^^^^^^^^^^^^ help: replace it with: `username`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
  --> src/auth.rs:52:13
   |
52 |             password: password
   |             ^^^^^^^^^^^^^^^^^^ help: replace it with: `password`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/models.rs:124:23
    |
124 |             Scrobble{ artist: artist, track: track, album: album, timestamp: None }
    |                       ^^^^^^^^^^^^^^ help: replace it with: `artist`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/models.rs:124:39
    |
124 |             Scrobble{ artist: artist, track: track, album: album, timestamp: None }
    |                                       ^^^^^^^^^^^^ help: replace it with: `track`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/models.rs:124:53
    |
124 |             Scrobble{ artist: artist, track: track, album: album, timestamp: None }
    |                                                     ^^^^^^^^^^^^ help: replace it with: `album`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: use of `or_insert` followed by a function call
  --> src/scrobbler.rs:67:47
   |
67 |         params.entry("timestamp".to_string()).or_insert(format!("{}", UNIX_EPOCH.elapsed().unwrap().as_secs()));
   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_insert_with(|| format!("{}", UNIX_EPOCH.elapsed().unwrap().as_secs()))`
   |
   = note: `#[warn(clippy::or_fun_call)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
  --> src/scrobbler.rs:80:19
   |
80 |         } else if batch_count <= 0 {
   |                   ^^^^^^^^^^^^^^^^
   |
   = note: `#[deny(clippy::absurd_extreme_comparisons)]` on by default
   = help: because 0 is the minimum value for this type, the case where the two sides are not equal never occurs, consider using batch_count == 0 instead
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#absurd_extreme_comparisons

warning: use of `or_insert` followed by a function call
  --> src/scrobbler.rs:86:60
   |
86 |             scrobble_params.entry("timestamp".to_string()).or_insert(format!("{}", UNIX_EPOCH.elapsed().unwrap().as_secs()));
   |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_insert_with(|| format!("{}", UNIX_EPOCH.elapsed().unwrap().as_secs()))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

warning: implementation of inherent method `to_string(&self) -> String` for type `client::ApiOperation`
  --> src/client.rs:22:5
   |
22 | /     fn to_string(&self) -> String {
23 | |         match *self {
24 | |             ApiOperation::AuthWebSession => "auth.getSession",
25 | |             ApiOperation::AuthMobileSession => "auth.getMobileSession",
...  |
29 | |         .to_string()
30 | |     }
   | |_____^
   |
   = note: `#[warn(clippy::inherent_to_string)]` on by default
   = help: implement trait `Display` for type `client::ApiOperation` instead
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#inherent_to_string
```