### PR TITLE
Remove deprecated Error::description and cause

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,15 +26,7 @@ impl fmt::Display for ScrobblerError {
     }
 }
 
-impl StdError for ScrobblerError {
-    fn description(&self) -> &str {
-        self.err_msg.as_str()
-    }
-
-    fn cause(&self) -> Option<&dyn StdError> {
-        None
-    }
-}
+impl StdError for ScrobblerError {}
 
 impl From<SystemTimeError> for ScrobblerError {
     fn from(error: SystemTimeError) -> Self {

--- a/src/scrobbler.rs
+++ b/src/scrobbler.rs
@@ -356,8 +356,8 @@ mod tests {
         let fmt = format!("{}", err);
         assert_eq!("test_error", fmt);
 
-        let desc = err.description();
-        assert_eq!("test_error", desc);
+        let desc = err.to_string();
+        assert_eq!("test_error", &desc);
 
         assert!(err.source().is_none());
     }


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes all implementation of `description` in `ScrobblerError `
- Replaces `description` usage

Related PR: https://github.com/rust-lang/rust/pull/66919